### PR TITLE
Update glide, fix ImageRenderer ctor

### DIFF
--- a/glidex.forms/ImageRenderer.cs
+++ b/glidex.forms/ImageRenderer.cs
@@ -1,4 +1,6 @@
-﻿using Android.Views;
+﻿using Android.Content;
+using Android.Runtime;
+using Android.Views;
 using System;
 using System.ComponentModel;
 using Xamarin.Forms;
@@ -17,6 +19,10 @@ namespace Android.Glide
 		bool _skipInvalidate;
 		int? _defaultLabelFor;
 		VisualElementTracker _visualElementTracker;
+
+		public ImageRenderer(Context context) : base (context) { }
+
+		public ImageRenderer(IntPtr javaReference, JniHandleOwnership transfer): base (javaReference, transfer) { }
 
 		protected override void Dispose (bool disposing)
 		{

--- a/glidex/glidex.csproj
+++ b/glidex/glidex.csproj
@@ -50,11 +50,8 @@
     <TransformFile Include="Transforms\EnumMethods.xml" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedJar Include="Jars\glide-full-4.6.1.jar">
-      <Url>https://github.com/bumptech/glide/releases/download/v4.6.1/glide-full-4.6.1.jar</Url>
-    </EmbeddedJar>
-    <EmbeddedJar Include="Jars\annotation-4.6.1.jar">
-      <Url>https://github.com/bumptech/glide/releases/download/v4.6.1/annotation-4.6.1.jar</Url>
+    <EmbeddedJar Include="Jars\glide-full-4.7.0.jar">
+      <Url>https://github.com/bumptech/glide/releases/download/v4.7.0/glide-full-4.7.0.jar</Url>
     </EmbeddedJar>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />


### PR DESCRIPTION
- Glide 4.7.0
- Dropped the annotation.jar, it seemed to not be needed in this library
- Fixed crash with `ImageRenderer` ctor when backgrounding sample apps