### PR TITLE
Support for new ImageButton in Xamarin.Forms 3.4.x

### DIFF
--- a/glidex.forms.sample/Forms/EdgeCasesPage.xaml.cs
+++ b/glidex.forms.sample/Forms/EdgeCasesPage.xaml.cs
@@ -13,6 +13,10 @@ namespace Android.Glide.Sample
 				HeightRequest = 50,
 				Source = Images.RandomSource (),
 			});
+			_stack.Children.Add (new ImageButton {
+				HeightRequest = 50,
+				Source = Images.RandomSource (),
+			});
 			_stack.Children.Add (new Image {
 				Source = ImageSource.FromFile ("doesn't exist")
 			});

--- a/glidex.forms.sample/glidex.forms.sample.csproj
+++ b/glidex.forms.sample/glidex.forms.sample.csproj
@@ -50,7 +50,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Xamarin.Forms" Version="3.4.0.1008975" />
     <PackageReference Include="Xamarin.Android.Support.Design" Version="27.0.2" />
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="27.0.2" />
     <PackageReference Include="Xamarin.Android.Support.v4" Version="27.0.2" />

--- a/glidex.forms/ImageButtonRenderer.cs
+++ b/glidex.forms/ImageButtonRenderer.cs
@@ -1,0 +1,17 @@
+﻿using Android.Content;
+using Xamarin.Forms;
+
+[assembly: ExportRenderer (typeof (ImageButton), typeof (Android.Glide.ImageButtonRenderer))]
+
+namespace Android.Glide
+{
+	public class ImageButtonRenderer : Xamarin.Forms.Platform.Android.ImageButtonRenderer
+	{
+		public ImageButtonRenderer (Context context) : base (context)
+		{
+			//HACK: workaround until https://github.com/xamarin/Xamarin.Forms/pull/4542 is released
+			// See https://github.com/jonathanpeppers/glidex/issues/16
+			Tag = null;
+		}
+	}
+}

--- a/glidex.forms/glidex.forms.csproj
+++ b/glidex.forms/glidex.forms.csproj
@@ -44,7 +44,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Xamarin.Forms" Version="3.4.0.1008975" />
     <PackageReference Include="Xamarin.Android.Support.Design" Version="27.0.2" />
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="27.0.2" />
     <PackageReference Include="Xamarin.Android.Support.v4" Version="27.0.2" />
@@ -54,6 +54,7 @@
   <ItemGroup>
     <Compile Include="Forms.cs" />
     <Compile Include="GlideExtensions.cs" />
+    <Compile Include="ImageButtonRenderer.cs" />
     <Compile Include="ImageViewHandler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/glidex.forms/glidex.forms.nuspec
+++ b/glidex.forms/glidex.forms.nuspec
@@ -17,7 +17,7 @@
         <tags>Xamarin, Xamarin.Forms, Android, Glide, Bitmap, Images</tags>
         <dependencies>
             <dependency id="glidex" version="$version$" />
-            <dependency id="Xamarin.Forms" version="3.3.0.912540" />
+            <dependency id="Xamarin.Forms" version="3.4.0.1008975" />
         </dependencies>
     </metadata>
 </package>


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/glidex/issues/16

Apparently, Glide uses `Tag` internally. So Xamarin.Forms can't set `Tag`!

To workaround this, I added a quick custom renderer to null out `Tag`. This is a workaround until a release of Xamarin.Forms with this change:

https://github.com/xamarin/Xamarin.Forms/pull/4542

Unfortunately, this also requires glidex.forms to bump its minimum dependency on Xamarin.Forms.