### PR TITLE
Reproduced/fixed issue if imageView.Context is not Activity

### DIFF
--- a/glidex.forms.sample/Forms/EdgeCasesPage.xaml.cs
+++ b/glidex.forms.sample/Forms/EdgeCasesPage.xaml.cs
@@ -17,6 +17,12 @@ namespace Android.Glide.Sample
 				HeightRequest = 50,
 				Source = Images.RandomSource (),
 			});
+			_stack.Children.Add (new Frame {
+				Content = new Image {
+					HeightRequest = 50,
+					Source = Images.RandomSource (),
+				},
+			});
 			_stack.Children.Add (new Image {
 				Source = ImageSource.FromFile ("doesn't exist")
 			});


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/glidex/issues/19
Context: https://github.com/xamarin/Xamarin.Forms/blob/94e6621f72cf3b19585253427aae4b70ba66af55/Xamarin.Forms.Platform.Android/Material/MaterialFrameRenderer.cs#L41

The problem surfaces when:
- Using Xamarin.Forms 4.x preview
- Enable `Visual="Material"` on the current page
- Use an `<Image/>` inside a `<Frame/>`

Since a `ContextThemeWrapper` is the `Context` of the `ImageView`, it
was hitting this `else`:

    else {
        Forms.Warn ("Context `{0}` is not an Android.App.Activity, aborting image load for `{1}`.", imageView.Context, source);
    }

I reworked this code so it also checks in `Forms.Context` to find the
`Activity` instance.