### PR TITLE
[ImageButton] workaround for NRE in ImageButtonRenderer.Draw

### DIFF
--- a/glidex.forms.sample/Forms/EdgeCasesPage.xaml.cs
+++ b/glidex.forms.sample/Forms/EdgeCasesPage.xaml.cs
@@ -15,6 +15,7 @@ namespace Android.Glide.Sample
 			});
 			_stack.Children.Add (new ImageButton {
 				HeightRequest = 50,
+				BackgroundColor = Color.Fuchsia,
 				Source = Images.RandomSource (),
 			});
 			_stack.Children.Add (new Frame {

--- a/glidex.forms/ImageButtonRenderer.cs
+++ b/glidex.forms/ImageButtonRenderer.cs
@@ -1,4 +1,5 @@
 ﻿using Android.Content;
+using Android.Graphics;
 using Xamarin.Forms;
 
 [assembly: ExportRenderer (typeof (ImageButton), typeof (Android.Glide.ImageButtonRenderer))]
@@ -12,6 +13,17 @@ namespace Android.Glide
 			//HACK: workaround until https://github.com/xamarin/Xamarin.Forms/pull/4542 is released
 			// See https://github.com/jonathanpeppers/glidex/issues/16
 			Tag = null;
+		}
+
+		/// <summary>
+		/// HACK: workaround until https://github.com/xamarin/Xamarin.Forms/pull/4783 is released
+		/// </summary>
+		public override void Draw (Canvas canvas)
+		{
+			if (Drawable == null)
+				return;
+
+			base.Draw (canvas);
 		}
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/glidex/issues/16
Context: https://github.com/xamarin/Xamarin.Forms/pull/4783