### PR TITLE
Remove obsolete Forms.Context.

### DIFF
--- a/glidex.forms.sample/Forms/ImageCellPage.xaml.cs
+++ b/glidex.forms.sample/Forms/ImageCellPage.xaml.cs
@@ -5,11 +5,11 @@ namespace Android.Glide.Sample
 {
     public partial class ImageCellPage
     {
-        public ImageCellPage()
+        public ImageCellPage ()
         {
-            InitializeComponent();
+            InitializeComponent ();
 
-            BindingContext = Images.RandomSources().ToArray();
+            BindingContext = Images.RandomSources ().ToArray ();
         }
     }
 }

--- a/glidex.forms.sample/Forms/ImageCellPage.xaml.cs
+++ b/glidex.forms.sample/Forms/ImageCellPage.xaml.cs
@@ -3,13 +3,13 @@ using Xamarin.Forms;
 
 namespace Android.Glide.Sample
 {
-	public partial class ImageCellPage
-	{
-		public ImageCellPage ()
-		{
-			InitializeComponent ();
+    public partial class ImageCellPage
+    {
+        public ImageCellPage()
+        {
+            InitializeComponent();
 
-			BindingContext = Images.RandomSources ().ToArray ();
-		}
-	}
+            BindingContext = Images.RandomSources().ToArray();
+        }
+    }
 }

--- a/glidex.forms.sample/Forms/ImageCellPage.xaml.cs
+++ b/glidex.forms.sample/Forms/ImageCellPage.xaml.cs
@@ -3,13 +3,13 @@ using Xamarin.Forms;
 
 namespace Android.Glide.Sample
 {
-    public partial class ImageCellPage
-    {
-        public ImageCellPage ()
-        {
-            InitializeComponent ();
+	public partial class ImageCellPage
+	{
+		public ImageCellPage ()
+		{
+			InitializeComponent ();
 
-            BindingContext = Images.RandomSources ().ToArray ();
-        }
-    }
+			BindingContext = Images.RandomSources ().ToArray ();
+		}
+	}
 }

--- a/glidex.forms.sample/MainActivity.cs
+++ b/glidex.forms.sample/MainActivity.cs
@@ -4,22 +4,22 @@ using Android.OS;
 
 namespace Android.Glide.Sample
 {
-	[Activity (Label = "glidex.forms.sample", Icon = "@drawable/icon", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
-	public class MainActivity : Xamarin.Forms.Platform.Android.FormsAppCompatActivity
-	{
-		protected override void OnCreate (Bundle bundle)
-		{
-			TabLayoutResource = Resource.Layout.Tabbar;
-			ToolbarResource = Resource.Layout.Toolbar;
+    [Activity(Label = "glidex.forms.sample", Icon = "@drawable/icon", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
+    public class MainActivity : Xamarin.Forms.Platform.Android.FormsAppCompatActivity
+    {
+        protected override void OnCreate(Bundle bundle)
+        {
+            TabLayoutResource = Resource.Layout.Tabbar;
+            ToolbarResource = Resource.Layout.Toolbar;
 
-			base.OnCreate (bundle);
+            base.OnCreate(bundle);
 
-			Xamarin.Forms.Forms.SetFlags ("Visual_Experimental");
-			Xamarin.Forms.Forms.Init (this, bundle);
-			//Force the custom renderers to get loaded
-			Android.Glide.Forms.Init (debug: true);
-			LoadApplication (new App ());
-		}
-	}
+            Xamarin.Forms.Forms.SetFlags("Visual_Experimental");
+            Xamarin.Forms.Forms.Init(this, bundle);
+            //Force the custom renderers to get loaded
+            Android.Glide.Forms.Init(this, debug: true);
+            LoadApplication(new App());
+        }
+    }
 }
 

--- a/glidex.forms.sample/MainActivity.cs
+++ b/glidex.forms.sample/MainActivity.cs
@@ -4,22 +4,22 @@ using Android.OS;
 
 namespace Android.Glide.Sample
 {
-    [Activity(Label = "glidex.forms.sample", Icon = "@drawable/icon", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
-    public class MainActivity : Xamarin.Forms.Platform.Android.FormsAppCompatActivity
-    {
-        protected override void OnCreate (Bundle bundle)
-        {
-            TabLayoutResource = Resource.Layout.Tabbar;
-            ToolbarResource = Resource.Layout.Toolbar;
+	[Activity (Label = "glidex.forms.sample", Icon = "@drawable/icon", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
+	public class MainActivity : Xamarin.Forms.Platform.Android.FormsAppCompatActivity
+	{
+		protected override void OnCreate (Bundle bundle)
+		{
+			TabLayoutResource = Resource.Layout.Tabbar;
+			ToolbarResource = Resource.Layout.Toolbar;
 
-            base.OnCreate (bundle);
+			base.OnCreate (bundle);
 
-            Xamarin.Forms.Forms.SetFlags ("Visual_Experimental");
-            Xamarin.Forms.Forms.Init (this, bundle);
-            //Force the custom renderers to get loaded
-            Android.Glide.Forms.Init (this, debug: true);
-            LoadApplication (new App ());
-        }
-    }
+			Xamarin.Forms.Forms.SetFlags ("Visual_Experimental");
+			Xamarin.Forms.Forms.Init (this, bundle);
+			//Force the custom renderers to get loaded
+			Android.Glide.Forms.Init (this, debug: true);
+			LoadApplication (new App ());
+		}
+	}
 }
 

--- a/glidex.forms.sample/MainActivity.cs
+++ b/glidex.forms.sample/MainActivity.cs
@@ -7,18 +7,18 @@ namespace Android.Glide.Sample
     [Activity(Label = "glidex.forms.sample", Icon = "@drawable/icon", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
     public class MainActivity : Xamarin.Forms.Platform.Android.FormsAppCompatActivity
     {
-        protected override void OnCreate(Bundle bundle)
+        protected override void OnCreate (Bundle bundle)
         {
             TabLayoutResource = Resource.Layout.Tabbar;
             ToolbarResource = Resource.Layout.Toolbar;
 
-            base.OnCreate(bundle);
+            base.OnCreate (bundle);
 
-            Xamarin.Forms.Forms.SetFlags("Visual_Experimental");
-            Xamarin.Forms.Forms.Init(this, bundle);
+            Xamarin.Forms.Forms.SetFlags ("Visual_Experimental");
+            Xamarin.Forms.Forms.Init (this, bundle);
             //Force the custom renderers to get loaded
-            Android.Glide.Forms.Init(this, debug: true);
-            LoadApplication(new App());
+            Android.Glide.Forms.Init (this, debug: true);
+            LoadApplication (new App ());
         }
     }
 }

--- a/glidex.forms/Forms.cs
+++ b/glidex.forms/Forms.cs
@@ -10,15 +10,25 @@ namespace Android.Glide
 	{
 		internal static Activity Activity { get; private set; }
 
+
 		/// <summary>
 		/// Initializes glidex.forms, put this after your `Xamarin.Forms.Forms.Init (this, bundle);` call.
 		/// </summary>
 		/// <param name="debug">Enables debug logging. Turn this on to verify Glide is being used in your app.</param>
+		[Obsolete ("Use Forms.Init(Activity,bool) instead.")]
+		public static void Init (bool debug = false)
+		{
+			Init ((Activity)Xamarin.Forms.Forms.Context, debug);
+		}
+
+		/// <summary>
+		/// Initializes glidex.forms, put this after your `Xamarin.Forms.Forms.Init (this, bundle);` call.
+		/// </summary>
+		/// <param name="activity">The MainActivity of your application.</param>
+		/// <param name="debug">Enables debug logging. Turn this on to verify Glide is being used in your app.</param>
 		public static void Init (Activity activity, bool debug = false)
 		{
 			Activity = activity;
-
-
 			IsDebugEnabled = debug;
 		}
 

--- a/glidex.forms/Forms.cs
+++ b/glidex.forms/Forms.cs
@@ -8,9 +8,7 @@ namespace Android.Glide
 	/// </summary>
 	public static class Forms
 	{
-		static bool initialized;
-
-        internal static Activity GlidexActivity { get; private set; }
+        internal static Activity Activity { get; private set; }
 
 		/// <summary>
 		/// Initializes glidex.forms, put this after your `Xamarin.Forms.Forms.Init (this, bundle);` call.
@@ -18,12 +16,10 @@ namespace Android.Glide
 		/// <param name="debug">Enables debug logging. Turn this on to verify Glide is being used in your app.</param>
 		public static void Init (Activity activity, bool debug = false)
 		{
-			if (initialized)
-				return;
+            Activity = activity; 
 
+			
 			IsDebugEnabled = debug;
-            GlidexActivity = activity; 
-			initialized = true;
 		}
 
 		/// <summary>

--- a/glidex.forms/Forms.cs
+++ b/glidex.forms/Forms.cs
@@ -8,7 +8,7 @@ namespace Android.Glide
 	/// </summary>
 	public static class Forms
 	{
-        internal static Activity Activity { get; private set; }
+		internal static Activity Activity { get; private set; }
 
 		/// <summary>
 		/// Initializes glidex.forms, put this after your `Xamarin.Forms.Forms.Init (this, bundle);` call.
@@ -16,9 +16,9 @@ namespace Android.Glide
 		/// <param name="debug">Enables debug logging. Turn this on to verify Glide is being used in your app.</param>
 		public static void Init (Activity activity, bool debug = false)
 		{
-            Activity = activity; 
+			Activity = activity;
 
-			
+
 			IsDebugEnabled = debug;
 		}
 
@@ -37,7 +37,7 @@ namespace Android.Glide
 			Util.Log.Warn (Tag, format, args);
 		}
 
-		internal static void Debug (string format, params object[] args)
+		internal static void Debug (string format, params object [] args)
 		{
 			if (IsDebugEnabled)
 				Util.Log.Debug (Tag, format, args);

--- a/glidex.forms/Forms.cs
+++ b/glidex.forms/Forms.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Android.App;
+using System;
 
 namespace Android.Glide
 {
@@ -9,17 +10,19 @@ namespace Android.Glide
 	{
 		static bool initialized;
 
+        internal static Activity GlidexActivity { get; private set; }
+
 		/// <summary>
 		/// Initializes glidex.forms, put this after your `Xamarin.Forms.Forms.Init (this, bundle);` call.
 		/// </summary>
 		/// <param name="debug">Enables debug logging. Turn this on to verify Glide is being used in your app.</param>
-		public static void Init (bool debug = false)
+		public static void Init (Activity activity, bool debug = false)
 		{
 			if (initialized)
 				return;
 
 			IsDebugEnabled = debug;
-
+            GlidexActivity = activity; 
 			initialized = true;
 		}
 

--- a/glidex.forms/GlideExtensions.cs
+++ b/glidex.forms/GlideExtensions.cs
@@ -75,8 +75,8 @@ namespace Android.Glide
 		/// </summary>
 		static bool IsActivityAlive (ImageView imageView, ImageSource source)
 		{
-			//NOTE: in some cases ContextThemeWrapper is Context, so only option is to look in Forms.Context for the Activity
-			var activity = imageView.Context as Activity ?? Xamarin.Forms.Forms.Context as Activity;
+            //NOTE: in some cases ContextThemeWrapper is Context, so only option is to look in Forms.Context for the Activity
+            var activity = imageView.Context as Activity ?? Forms.GlidexActivity;
 			if (activity != null) {
 				if (activity.IsFinishing) {
 					Forms.Warn ("Activity of type `{0}` is finishing, aborting image load for `{1}`.", activity.GetType ().FullName, source);

--- a/glidex.forms/GlideExtensions.cs
+++ b/glidex.forms/GlideExtensions.cs
@@ -75,8 +75,8 @@ namespace Android.Glide
 		/// </summary>
 		static bool IsActivityAlive (ImageView imageView, ImageSource source)
 		{
-            //NOTE: in some cases ContextThemeWrapper is Context
-            var activity = imageView.Context as Activity ?? Forms.Activity;
+			//NOTE: in some cases ContextThemeWrapper is Context
+			var activity = imageView.Context as Activity ?? Forms.Activity;
 			if (activity != null) {
 				if (activity.IsFinishing) {
 					Forms.Warn ("Activity of type `{0}` is finishing, aborting image load for `{1}`.", activity.GetType ().FullName, source);

--- a/glidex.forms/GlideExtensions.cs
+++ b/glidex.forms/GlideExtensions.cs
@@ -75,7 +75,7 @@ namespace Android.Glide
 		/// </summary>
 		static bool IsActivityAlive (ImageView imageView, ImageSource source)
 		{
-            //NOTE: in some cases ContextThemeWrapper is Context, so only option is to look in Forms.Context for the Activity
+            //NOTE: in some cases ContextThemeWrapper is Context
             var activity = imageView.Context as Activity ?? Forms.GlidexActivity;
 			if (activity != null) {
 				if (activity.IsFinishing) {

--- a/glidex.forms/GlideExtensions.cs
+++ b/glidex.forms/GlideExtensions.cs
@@ -76,7 +76,7 @@ namespace Android.Glide
 		static bool IsActivityAlive (ImageView imageView, ImageSource source)
 		{
             //NOTE: in some cases ContextThemeWrapper is Context
-            var activity = imageView.Context as Activity ?? Forms.GlidexActivity;
+            var activity = imageView.Context as Activity ?? Forms.Activity;
 			if (activity != null) {
 				if (activity.IsFinishing) {
 					Forms.Warn ("Activity of type `{0}` is finishing, aborting image load for `{1}`.", activity.GetType ().FullName, source);


### PR DESCRIPTION
Hi @jonathanpeppers , this PR don't change any logic... Just provides a new way to get the Activity/Context. I hope you like this.

Now in MainActivity the user needs to pass the Activity into the `Init`.

```csharp
Xamarin.Forms.Forms.Init(this, bundle);
//Force the custom renderers to get loaded
Android.Glide.Forms.Init(this, debug: true);
LoadApplication(new App());
```