### PR TITLE
Recheck IsActivityAlive() after await call

### DIFF
--- a/glidex.forms.sample/MainActivity.cs
+++ b/glidex.forms.sample/MainActivity.cs
@@ -14,7 +14,7 @@ namespace Android.Glide.Sample
 
 			base.OnCreate (bundle);
 
-			Xamarin.Forms.Forms.SetFlags ("Visual_Experimental");
+			Xamarin.Forms.Forms.SetFlags ("Visual_Experimental", "FastRenderers_Experimental");
 			Xamarin.Forms.Forms.Init (this, bundle);
 			//Force the custom renderers to get loaded
 			Android.Glide.Forms.Init (this, debug: true);

--- a/glidex.forms/GlideExtensions.cs
+++ b/glidex.forms/GlideExtensions.cs
@@ -52,6 +52,8 @@ namespace Android.Glide
 						using (var stream = await streamSource.Stream (token)) {
 							if (token.IsCancellationRequested || stream == null)
 								return;
+							if (!IsActivityAlive (imageView, source))
+								return;
 							stream.CopyTo (memoryStream);
 							builder = request.Load (memoryStream.ToArray ());
 						}
@@ -75,6 +77,13 @@ namespace Android.Glide
 		/// </summary>
 		static bool IsActivityAlive (ImageView imageView, ImageSource source)
 		{
+			// The imageView.Handle could be IntPtr.Zero? Meaning we somehow have a reference to a disposed ImageView...
+			// I think this is within the realm of "possible" after the await call in LoadViaGlide().
+			if (imageView.Handle == IntPtr.Zero) {
+				Forms.Warn ("imageView.Handle is IntPtr.Zero, aborting image load for `{0}`.", source);
+				return false;
+			}
+
 			//NOTE: in some cases ContextThemeWrapper is Context
 			var activity = imageView.Context as Activity ?? Forms.Activity;
 			if (activity != null) {


### PR DESCRIPTION
Might fix: https://github.com/jonathanpeppers/glidex/issues/36

While using `FastRenderers_Experimental`, an error is received such as:

    System.NotSupportedException: Unable to activate instance of type Xamarin.Forms.Platform.Android.FastRenderers.ImageRenderer from native handle 0xff892f3c (key_handle 0xfc8cb10).
        at Java.Interop.TypeManager.CreateInstance (System.IntPtr handle, Android.Runtime.JniHandleOwnership transfer, System.Type targetType) [0x00182] in <2960acf2eeb24d88b5230e1e8afbdc2e>:0
        at Java.Lang.Object.GetObject (System.IntPtr handle, Android.Runtime.JniHandleOwnership transfer, System.Type type) [0x000c1] in <2960acf2eeb24d88b5230e1e8afbdc2e>:0
        at Java.Lang.Object._GetObject[T] (System.IntPtr handle, Android.Runtime.JniHandleOwnership transfer) [0x00017] in <2960acf2eeb24d88b5230e1e8afbdc2e>:0
        at Java.Lang.Object.GetObject[T] (System.IntPtr handle, Android.Runtime.JniHandleOwnership transfer) [0x00000] in <2960acf2eeb24d88b5230e1e8afbdc2e>:0
        at Java.Lang.Object.GetObject[T] (System.IntPtr jnienv, System.IntPtr handle, Android.Runtime.JniHandleOwnership transfer) [0x00006] in <2960acf2eeb24d88b5230e1e8afbdc2e>:0
        at Android.Views.View.n_Invalidate (System.IntPtr jnienv, System.IntPtr native__this) [0x00000] in <2960acf2eeb24d88b5230e1e8afbdc2e>:0
        at (wrapper dynamic-method) Android.Runtime.DynamicMethodNameCounter.58(intptr,intptr)
    --- End of inner exception stack trace ---
    System.MissingMethodException: No constructor found for Xamarin.Forms.Platform.Android.FastRenderers.ImageRenderer::.ctor(System.IntPtr, Android.Runtime.JniHandleOwnership)
        at Java.Interop.TypeManager.CreateProxy (System.Type type, System.IntPtr handle, Android.Runtime.JniHandleOwnership transfer) [0x00055] in <2960acf2eeb24d88b5230e1e8afbdc2e>:0
        at Java.Interop.TypeManager.CreateInstance (System.IntPtr handle, Android.Runtime.JniHandleOwnership transfer, System.Type targetType) [0x00116] in <2960acf2eeb24d88b5230e1e8afbdc2e>:0
    --- End of inner exception stack trace ---
        Java.Interop.JavaLocationException: Exception of type 'Java.Interop.JavaLocationException' was thrown.
        at Java.Lang.Error: Exception of type 'Java.Lang.Error' was thrown.
        at java.lang.Error: Java callstack:
        at md5f92e0daf340890c9667469657ee2ece8.ImageRenderer.n_invalidate(Native Method)
        at md5f92e0daf340890c9667469657ee2ece8.ImageRenderer.invalidate(ImageRenderer.java:54)
        at android.widget.ImageView.setImageDrawable(ImageView.java:573)
        at com.bumptech.glide.request.target.DrawableImageViewTarget.setResource(DrawableImageViewTarget.java:28)
        at com.bumptech.glide.request.target.DrawableImageViewTarget.setResource(DrawableImageViewTarget.java:10)
        at com.bumptech.glide.request.target.ImageViewTarget.setResourceInternal(ImageViewTarget.java:127)
        at com.bumptech.glide.request.target.ImageViewTarget.onResourceReady(ImageViewTarget.java:104)
        at com.bumptech.glide.request.SingleRequest.onResourceReady(SingleRequest.java:579)
        at com.bumptech.glide.request.SingleRequest.onResourceReady(SingleRequest.java:549)
        at com.bumptech.glide.load.engine.EngineJob.handleResultOnMainThread(EngineJob.java:218)
        at com.bumptech.glide.load.engine.EngineJob$MainThreadCallback.handleMessage(EngineJob.java:324)
        at android.os.Handler.dispatchMessage(Handler.java:102)
        at android.os.Looper.loop(Looper.java:193)
        at android.app.ActivityThread.main(ActivityThread.java:6680)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)

Other facts:

* The image is `EmbeddedResource`.
* Happens when navigating pages back and forth.

The theory is that Glide (from the Java world) is trying to set the
image on an `ImageView` from a page that is no longer present.

When reviewing the code, the single `await` call does not appear to
check a couple things:

* `IsActivityAlive()` should be re-checked.
* Worst case scenario, we should check if the `ImageView` got
  disposed. I added this check in `IsActivityAlive()`.

Same technique is used in this Xamarin.Forms extension method:

https://github.com/xamarin/Xamarin.Forms/blob/bd31e1e9fc8b2f9ad94cc99e0c7ab058174821f3/Xamarin.Forms.Platform.Android/Extensions/JavaObjectExtensions.cs