### PR TITLE
IGlideHandler implementation

### DIFF
--- a/glidex.forms.sample/MainActivity.cs
+++ b/glidex.forms.sample/MainActivity.cs
@@ -18,6 +18,8 @@ namespace Android.Glide.Sample
 			Xamarin.Forms.Forms.Init (this, bundle);
 			//Force the custom renderers to get loaded
 			Android.Glide.Forms.Init (this, debug: true);
+			// Or use this one instead to try IGlideHandler
+			// Android.Glide.Forms.Init (this, handler: new RandomAlphaHandler (), debug: true);
 			LoadApplication (new App ());
 		}
 	}

--- a/glidex.forms.sample/RandomAlphaHandler.cs
+++ b/glidex.forms.sample/RandomAlphaHandler.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Threading;
+using Android.Graphics.Drawables;
+using Android.Widget;
+using Bumptech.Glide;
+using Bumptech.Glide.Request.Target;
+using Bumptech.Glide.Request.Transition;
+using Xamarin.Forms;
+
+namespace Android.Glide.Sample
+{
+	public class RandomAlphaHandler : IGlideHandler
+	{
+		public bool Build (ImageView imageView, ImageSource source, RequestBuilder builder, CancellationToken token)
+		{
+			if (builder != null) {
+				builder.Into (new MyTarget (imageView));
+				return true;
+			} else {
+				return false;
+			}
+		}
+
+		class MyTarget : SimpleTarget
+		{
+			static readonly Random rand = new Random();
+			readonly ImageView imageView;
+
+			public MyTarget (ImageView imageView)
+			{
+				this.imageView = imageView;
+			}
+
+			public override void OnResourceReady (Java.Lang.Object resource, ITransition transition)
+			{
+				if (resource is BitmapDrawable bitmap) {
+					bitmap.Alpha = rand.Next (0, 255);
+					imageView.SetImageDrawable (bitmap);
+				}
+			}
+		}
+	}
+}

--- a/glidex.forms.sample/glidex.forms.sample.csproj
+++ b/glidex.forms.sample/glidex.forms.sample.csproj
@@ -49,7 +49,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.0.0.135214-pre4" />
+    <PackageReference Include="Xamarin.Forms" Version="4.0.0.425677" />
     <PackageReference Include="Xamarin.Android.Support.Design" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.v4" Version="28.0.0.1" />
@@ -91,6 +91,7 @@
     <Compile Include="Forms\ViewCellPage.xaml.cs">
       <DependentUpon>ViewCellPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="RandomAlphaHandler.cs" />
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\drawable\icon.png" />

--- a/glidex.forms/Forms.cs
+++ b/glidex.forms/Forms.cs
@@ -9,7 +9,9 @@ namespace Android.Glide
 	/// </summary>
 	public static class Forms
 	{
-		internal static Activity Activity { get; set; }
+		internal static Activity Activity { get; private set; }
+
+		internal static IGlideHandler GlideHandler { get; private set; }
 
 		static readonly ActivityLifecycle lifecycle = new ActivityLifecycle ();
 
@@ -20,17 +22,19 @@ namespace Android.Glide
 		[Obsolete ("Use Forms.Init(Activity,bool) instead.")]
 		public static void Init (bool debug = false)
 		{
-			Init ((Activity)Xamarin.Forms.Forms.Context, debug);
+			Init ((Activity)Xamarin.Forms.Forms.Context, debug: debug);
 		}
 
 		/// <summary>
 		/// Initializes glidex.forms, put this after your `Xamarin.Forms.Forms.Init (this, bundle);` call.
 		/// </summary>
 		/// <param name="activity">The MainActivity of your application.</param>
+		/// <param name="handler">An implementation of IGlideHandler for customizing calls to Glide.</param>
 		/// <param name="debug">Enables debug logging. Turn this on to verify Glide is being used in your app.</param>
-		public static void Init (Activity activity, bool debug = false)
+		public static void Init (Activity activity, IGlideHandler handler = null, bool debug = false)
 		{
 			Activity = activity;
+			GlideHandler = handler;
 			IsDebugEnabled = debug;
 			activity.Application.RegisterActivityLifecycleCallbacks (lifecycle);
 		}

--- a/glidex.forms/GlideExtensions.cs
+++ b/glidex.forms/GlideExtensions.cs
@@ -62,6 +62,14 @@ namespace Android.Glide
 						break;
 				}
 
+				var handler = Forms.GlideHandler;
+				if (handler != null) {
+					Forms.Debug ("Calling into {0} of type `{1}`.", nameof (IGlideHandler), handler.GetType ());
+					 if (handler.Build (imageView, source, builder, token)) {
+						return;
+					}
+				}
+
 				if (builder is null) {
 					Clear (request, imageView);
 				} else {

--- a/glidex.forms/IGlideHandler.cs
+++ b/glidex.forms/IGlideHandler.cs
@@ -1,0 +1,23 @@
+﻿using System.Threading;
+using Android.Widget;
+using Bumptech.Glide;
+using Xamarin.Forms;
+
+namespace Android.Glide
+{
+	/// <summary>
+	/// Interface for customizing calls to Glide
+	/// </summary>
+	public interface IGlideHandler
+	{
+		/// <summary>
+		/// A callback that glidex.forms calls prior to making default calls to Glide
+		/// </summary>
+		/// <param name="imageView">The Android ImageView</param>
+		/// <param name="source">The ImageSource from Xamarin.Forms</param>
+		/// <param name="builder">Might be null, the Glide RequestBuilder object to work with</param>
+		/// <param name="token">The CancellationToken if you need it</param>
+		/// <returns>True if the image was handled. Return false if you need the image to be cleared for you.</returns>
+		bool Build (ImageView imageView, ImageSource source, RequestBuilder builder, CancellationToken token);
+	}
+}

--- a/glidex.forms/glidex.forms.csproj
+++ b/glidex.forms/glidex.forms.csproj
@@ -53,6 +53,7 @@
     <Compile Include="GlideExtensions.cs" />
     <Compile Include="ImageViewHandler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="IGlideHandler.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/glidex/issues/28

This is my initial idea that allows developers to implement their own
calls to Glide in a simple way.

For example `RandomAlphaHandler` creates a `SimpleTarget` subclass
that sets a random alpha value on the `BitmapDrawable`.

When subclassing `SimpleTarget`, you can also override:

* `OnLoadStarted`
* `OnLoadFailed`

This should give developers flexibility for what happens if images
fail to load, etc.

TODO:
* Let someone else try out my API?
* Write a few other `IGlideHandler` examples