### PR TITLE
[build] locate MSBuild properly

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -25,25 +25,17 @@ Task("Clean")
             CleanDirectory(dir);
     });
 
-Task("Restore-NuGet-Packages")
-    .IsDependentOn("Clean")
-    .Does(() =>
-    {
-        NuGetRestore(sln);
-    });
-
 Task("Build")
-    .IsDependentOn("Restore-NuGet-Packages")
     .Does(() =>
     {
-        MSBuild(sln, settings => settings.SetConfiguration(configuration));
+        MSBuild(sln, MSBuildSettings());
     });
 
 Task("Install")
     .IsDependentOn("Build")
     .Does(() =>
     {
-        MSBuild("./glidex.forms.sample/glidex.forms.sample.csproj", settings => settings.SetConfiguration(configuration).WithTarget("Install").WithTarget("_Run"));
+        MSBuild("./glidex.forms.sample/glidex.forms.sample.csproj", MSBuildSettings().WithTarget("Install").WithTarget("_Run"));
     });
 
 Task("NuGet-Package")

--- a/helpers.cake
+++ b/helpers.cake
@@ -27,3 +27,34 @@ void push(string file)
         ApiKey = apiKey
     });
 }
+
+MSBuildSettings MSBuildSettings()
+{
+    var settings = new MSBuildSettings { Configuration = configuration };
+
+    if (IsRunningOnWindows())
+    {
+        // Find MSBuild for Visual Studio 2019 and newer
+        DirectoryPath vsLatest = VSWhereLatest();
+        FilePath msBuildPath = vsLatest?.CombineWithFilePath("./MSBuild/Current/Bin/MSBuild.exe");
+
+        // Find MSBuild for Visual Studio 2017
+        if (msBuildPath != null && !FileExists(msBuildPath))
+            msBuildPath = vsLatest.CombineWithFilePath("./MSBuild/15.0/Bin/MSBuild.exe");
+
+        // Have we found MSBuild yet?
+        if (!FileExists(msBuildPath))
+        {
+            throw new Exception($"Failed to find MSBuild: {msBuildPath}");
+        }
+
+        Information("Building using MSBuild at " + msBuildPath);
+        settings.ToolPath = msBuildPath;
+    }
+    else
+    {
+        settings.ToolPath = Context.Tools.Resolve("msbuild");
+    }
+
+    return settings.WithRestore();
+}


### PR DESCRIPTION
Context: https://github.com/jonathanpeppers/Xamarin.Forms.Mocks/pull/43

I tried to build this repo on a new machine that only has VS 2019 installed. It didn't build...

I pulled a fix over that NUnit is using in their Cake script.

I also just use MSBuild restore now instead of NuGet.