### PR TITLE
Cancel Glide requests in Dispose()

### DIFF
--- a/glidex.forms.sample/Forms/ListViewOfDoom.xaml
+++ b/glidex.forms.sample/Forms/ListViewOfDoom.xaml
@@ -3,10 +3,12 @@
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Android.Glide.Sample.ListViewOfDoom">
-    <ListView ItemsSource="{Binding}" CachingStrategy="RecycleElement">
+    <ListView ItemsSource="{Binding}" CachingStrategy="RecycleElement" RowHeight="200">
         <ListView.ItemTemplate>
             <DataTemplate>
-                <ImageCell Text="Random URLs" ImageSource="{Binding}" />
+                <ViewCell>
+                    <Image Source="{Binding}" />
+                </ViewCell>
             </DataTemplate>
         </ListView.ItemTemplate>
     </ListView>

--- a/glidex.forms/GlideExtensions.cs
+++ b/glidex.forms/GlideExtensions.cs
@@ -65,7 +65,7 @@ namespace Android.Glide
 				var handler = Forms.GlideHandler;
 				if (handler != null) {
 					Forms.Debug ("Calling into {0} of type `{1}`.", nameof (IGlideHandler), handler.GetType ());
-					 if (handler.Build (imageView, source, builder, token)) {
+					if (handler.Build (imageView, source, builder, token)) {
 						return;
 					}
 				}
@@ -120,6 +120,16 @@ namespace Android.Glide
 			//We need to call Clear for Glide to know this image is now unused
 			//https://bumptech.github.io/glide/doc/targets.html
 			request.Clear (imageView);
+		}
+
+		internal static void CancelGlide (this ImageView imageView)
+		{
+			if (!IsActivityAlive (imageView, null)) {
+				return;
+			}
+
+			RequestManager request = With (imageView.Context);
+			Clear (request, imageView);
 		}
 	}
 }

--- a/glidex.forms/ImageRenderer.cs
+++ b/glidex.forms/ImageRenderer.cs
@@ -1,0 +1,19 @@
+﻿using Android.Content;
+using Xamarin.Forms;
+
+[assembly: ExportRenderer (typeof (Image), typeof (Android.Glide.ImageRenderer))]
+
+namespace Android.Glide
+{
+	public class ImageRenderer : Xamarin.Forms.Platform.Android.FastRenderers.ImageRenderer
+	{
+		public ImageRenderer (Context context) : base (context) { }
+
+		protected override void Dispose (bool disposing)
+		{
+			this.CancelGlide ();
+
+			base.Dispose (disposing);
+		}
+	}
+}

--- a/glidex.forms/glidex.forms.csproj
+++ b/glidex.forms/glidex.forms.csproj
@@ -49,6 +49,7 @@
   <ItemGroup>
     <Compile Include="Forms.cs" />
     <Compile Include="GlideExtensions.cs" />
+    <Compile Include="ImageRenderer.cs" />
     <Compile Include="ImageViewHandler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="IGlideHandler.cs" />


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/glidex/issues/45

Thanks @activa! I could finally reproduce this!

The problem here is we need to cancel any in-flight Glide requests
when the `ImageRenderer` is disposed. Otherwise, Java completes the
request against a C# object that is no longer alive.

There may be a future fix needed here for `ImageCell`, but I wasn't
able to reproduce a problem there.