### PR TITLE
Require Xamarin.Forms 4.0.0 as minimum

### DIFF
--- a/glidex.forms/glidex.forms.nuspec
+++ b/glidex.forms/glidex.forms.nuspec
@@ -18,7 +18,7 @@
         <tags>Xamarin, Xamarin.Forms, Android, Glide, Bitmap, Images</tags>
         <dependencies>
             <dependency id="Xamarin.Android.Glide" version="4.9.0" />
-            <dependency id="Xamarin.Forms" version="3.4.0.1029999" />
+            <dependency id="Xamarin.Forms" version="4.0.0.709238" />
         </dependencies>
     </metadata>
 </package>


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/glidex/issues/54

It appears that the "fast renderer" version of `ImageRenderer` was `internal` until Xamarin.Forms 4.0. We need to make the minimum version of Xamarin.Forms 4.0 to match.