### PR TITLE
Fixes for Xamarin.Forms 4.4

### DIFF
--- a/glidex.forms.sample/Forms/App.xaml.cs
+++ b/glidex.forms.sample/Forms/App.xaml.cs
@@ -9,6 +9,9 @@ namespace Android.Glide.Sample
 			InitializeComponent();
 
 			MainPage = new NavigationPage (new MainPage ());
+
+			// Uncomment to test issues while exiting the app
+			//MainPage = new ToggleSourcePage ();
 		}
 	}
 }

--- a/glidex.forms.sample/glidex.forms.sample.csproj
+++ b/glidex.forms.sample/glidex.forms.sample.csproj
@@ -51,7 +51,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.1.0.673156" />
+    <PackageReference Include="Xamarin.Forms" Version="4.4.0.991477" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Forms\EdgeCasesPage.xaml.cs">

--- a/glidex.forms/ImageButtonRenderer.cs
+++ b/glidex.forms/ImageButtonRenderer.cs
@@ -1,0 +1,19 @@
+﻿using Android.Content;
+using Xamarin.Forms;
+
+[assembly: ExportRenderer (typeof (ImageButton), typeof (Android.Glide.ImageButtonRenderer))]
+
+namespace Android.Glide
+{
+	public class ImageButtonRenderer : Xamarin.Forms.Platform.Android.ImageButtonRenderer
+	{
+		public ImageButtonRenderer (Context context) : base (context) { }
+
+		protected override void Dispose (bool disposing)
+		{
+			this.CancelGlide ();
+
+			base.Dispose (disposing);
+		}
+	}
+}

--- a/glidex.forms/glidex.forms.csproj
+++ b/glidex.forms/glidex.forms.csproj
@@ -43,12 +43,13 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.1.0.673156" ExcludeAssets="build" />
+    <PackageReference Include="Xamarin.Forms" Version="4.4.0.991477" ExcludeAssets="build" />
     <PackageReference Include="Xamarin.Android.Glide" Version="4.9.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Forms.cs" />
     <Compile Include="GlideExtensions.cs" />
+    <Compile Include="ImageButtonRenderer.cs" />
     <Compile Include="ImageRenderer.cs" />
     <Compile Include="ImageViewHandler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/glidex/issues/57

Most of these are actually correctness fixes. I am not sure how
Xamarin.Forms 4.4 triggered these, but they were not quite right:

* We need an `ImageButtonRenderer` and call `CancelGlide` in `Dispose`

* `CancelGlide` should use the `Application.Context` to call
  `With(Application.Context).Clear(imageView)`. This will work even if
  the `Activity` is destroyed.

* Cases that check `IsActivityAlive` and `return` should call
  `CancelGlide`