### PR TITLE
Use Xamarin.Android.Glide 4.11.0

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -16,7 +16,7 @@ var dirs = new[]
 };
 string output = dirs[0];
 string sln = "./glidex.sln";
-string version = "2.0.1";
+string version = "2.1.0";
 string suffix = "";
 
 string buildNumber = Environment.GetEnvironmentVariable ("BUILD_BUILDNUMBER");

--- a/glidex.forms.sample/Properties/AndroidManifest.xml
+++ b/glidex.forms.sample/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.companyname.glidex.forms.sample">
-	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="28" />
+	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="29" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<application android:label="glidex.forms.sample"></application>
 </manifest>

--- a/glidex.forms.sample/glidex.forms.sample.csproj
+++ b/glidex.forms.sample/glidex.forms.sample.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Android.Glide.Sample</RootNamespace>
     <AssemblyName>glidex.forms.sample</AssemblyName>
-    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
     <AndroidApplication>True</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
@@ -51,7 +51,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.4.0.991477" />
+    <PackageReference Include="Xamarin.Forms" Version="4.5.0.356" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Forms\EdgeCasesPage.xaml.cs">

--- a/glidex.forms/glidex.forms.csproj
+++ b/glidex.forms/glidex.forms.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Xamarin.Forms.2.5.0.280555\build\netstandard1.0\Xamarin.Forms.props" Condition="Exists('..\packages\Xamarin.Forms.2.5.0.280555\build\netstandard1.0\Xamarin.Forms.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -15,7 +14,7 @@
     <FileAlignment>512</FileAlignment>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
     <DebugType>portable</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -43,8 +42,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.4.0.991477" ExcludeAssets="build" />
-    <PackageReference Include="Xamarin.Android.Glide" Version="4.9.0" />
+    <PackageReference Include="Xamarin.Forms" Version="4.5.0.356" ExcludeAssets="build" />
+    <PackageReference Include="Xamarin.Android.Glide" Version="4.11.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Forms.cs" />

--- a/glidex.forms/glidex.forms.nuspec
+++ b/glidex.forms/glidex.forms.nuspec
@@ -17,8 +17,10 @@
         <releaseNotes></releaseNotes>
         <tags>Xamarin, Xamarin.Forms, Android, Glide, Bitmap, Images</tags>
         <dependencies>
-            <dependency id="Xamarin.Android.Glide" version="4.9.0" />
-            <dependency id="Xamarin.Forms" version="4.0.0.709238" />
+            <group targetFramework="MonoAndroid10.0">
+                <dependency id="Xamarin.Android.Glide" version="4.11.0" />
+                <dependency id="Xamarin.Forms" version="4.5.0.356" />
+            </group>
         </dependencies>
     </metadata>
 </package>


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/glidex/issues/64
Fixes: https://github.com/jonathanpeppers/glidex/issues/62

Some notes on what changes here:

* Bump version to 2.1.x
* `MonoAndroid10.0` is required
* AndroidX is required
* Xamarin.Forms 4.5.x is required