### PR TITLE
IImageSourceHandler impl

### DIFF
--- a/glidex.forms.sample/RandomAlphaHandler.cs
+++ b/glidex.forms.sample/RandomAlphaHandler.cs
@@ -21,6 +21,11 @@ namespace Android.Glide.Sample
 			}
 		}
 
+		public void Build (ImageSource source, RequestBuilder builder, CancellationToken token)
+		{
+			
+		}
+
 		class MyTarget : SimpleTarget
 		{
 			static readonly Random rand = new Random();

--- a/glidex.forms.sample/Resources/layout/Tabbar.axml
+++ b/glidex.forms.sample/Resources/layout/Tabbar.axml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.TabLayout xmlns:android="http://schemas.android.com/apk/res/android"
+﻿<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.tabs.TabLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/sliding_tabs"
     android:layout_width="match_parent"

--- a/glidex.forms.sample/Resources/layout/Toolbar.axml
+++ b/glidex.forms.sample/Resources/layout/Toolbar.axml
@@ -1,4 +1,4 @@
-<android.support.v7.widget.Toolbar
+﻿<androidx.appcompat.widget.Toolbar
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/toolbar"
     android:layout_width="match_parent"

--- a/glidex.forms/GlideExtensions.cs
+++ b/glidex.forms/GlideExtensions.cs
@@ -3,9 +3,12 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Android.App;
+using Android.Content;
+using Android.Graphics;
 using Android.Views;
 using Android.Widget;
 using Bumptech.Glide;
+using Java.Util.Concurrent;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
 using static Bumptech.Glide.Glide;
@@ -60,7 +63,7 @@ namespace Android.Glide
 								CancelGlide (imageView);
 								return;
 							}
-							stream.CopyTo (memoryStream);
+							await stream.CopyToAsync (memoryStream, token);
 							builder = request.Load (memoryStream.ToArray ());
 						}
 						break;
@@ -84,6 +87,100 @@ namespace Android.Glide
 				//Since developers can't catch this themselves, I think we should log it and silently fail
 				Forms.Warn ("Unexpected exception in glidex: {0}", exc);
 			}
+		}
+
+		public static async Task<Bitmap> LoadViaGlide (this ImageSource source, Context context, CancellationToken token)
+		{
+			try {
+				if (!IsActivityAlive (context, source))
+					return null;
+
+				RequestManager request = With (context);
+				RequestBuilder builder = null;
+
+				if (source is null) {
+					Forms.Debug ("`{0}` is null", nameof (ImageSource));
+					return null;
+				}
+
+				switch (source) {
+					case FileImageSource fileSource:
+						var fileName = fileSource.File;
+						var drawable = ResourceManager.GetDrawableByName (fileName);
+						if (drawable != 0) {
+							Forms.Debug ("Loading `{0}` as an Android resource", fileName);
+							builder = request.AsBitmap ().Load (drawable);
+						} else {
+							Forms.Debug ("Loading `{0}` from disk", fileName);
+							builder = request.AsBitmap ().Load (fileName);
+						}
+						break;
+
+					case UriImageSource uriSource:
+						var url = uriSource.Uri.OriginalString;
+						Forms.Debug ("Loading `{0}` as a web URL", url);
+						builder = request.AsBitmap ().Load (url);
+						break;
+
+					case StreamImageSource streamSource:
+						Forms.Debug ("Loading `{0}` as a byte[]. Consider using `AndroidResource` instead, as it would be more performant", nameof (StreamImageSource));
+						using (var memoryStream = new MemoryStream ())
+						using (var stream = await streamSource.Stream (token)) {
+							if (token.IsCancellationRequested || stream == null)
+								return null;
+							if (!IsActivityAlive (context, source)) {
+								return null;
+							}
+							await stream.CopyToAsync (memoryStream, token);
+							builder = request.AsBitmap ().Load (memoryStream.ToArray ());
+						}
+						break;
+				}
+
+				var handler = Forms.GlideHandler;
+				if (handler != null) {
+					Forms.Debug ("Calling into {0} of type `{1}`.", nameof (IGlideHandler), handler.GetType ());
+					handler.Build (source, builder, token);
+				}
+
+				if (builder is null) {
+					return null;
+				} else {
+					var result = await builder.Submit ().GetAsync ();
+					return (Bitmap) result;
+				}
+
+			} catch (Exception exc) {
+				//Since developers can't catch this themselves, I think we should log it and silently fail
+				Forms.Warn ("Unexpected exception in glidex: {0}", exc);
+				return null;
+			}
+		}
+
+		static bool IsActivityAlive (Context context, ImageSource source)
+		{
+			if (context == null || context.Handle == IntPtr.Zero) {
+				Forms.Warn ("imageView.Handle is IntPtr.Zero, aborting image load for `{0}`.", source);
+				return false;
+			}
+
+			//NOTE: in some cases ContextThemeWrapper is Context
+			var activity = context as Activity ?? Forms.Activity;
+			if (activity != null) {
+				if (activity.IsFinishing) {
+					Forms.Warn ("Activity of type `{0}` is finishing, aborting image load for `{1}`.", activity.GetType ().FullName, source);
+					return false;
+				}
+				if (activity.IsDestroyed) {
+					Forms.Warn ("Activity of type `{0}` is destroyed, aborting image load for `{1}`.", activity.GetType ().FullName, source);
+					return false;
+				}
+			} else {
+				Forms.Warn ("Context `{0}` is not an Android.App.Activity and could not use Android.Glide.Forms.Activity, aborting image load for `{1}`.", context, source);
+				return false;
+			}
+
+			return true;
 		}
 
 		/// <summary>

--- a/glidex.forms/IGlideHandler.cs
+++ b/glidex.forms/IGlideHandler.cs
@@ -19,5 +19,6 @@ namespace Android.Glide
 		/// <param name="token">The CancellationToken if you need it</param>
 		/// <returns>True if the image was handled. Return false if you need the image to be cleared for you.</returns>
 		bool Build (ImageView imageView, ImageSource source, RequestBuilder builder, CancellationToken token);
+		void Build (ImageSource source, RequestBuilder builder, CancellationToken token);
 	}
 }

--- a/glidex.forms/ImageViewHandler.cs
+++ b/glidex.forms/ImageViewHandler.cs
@@ -1,18 +1,16 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using Android.Content;
+using Android.Graphics;
 using Android.Runtime;
 using Android.Widget;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
 
-[assembly: ExportImageSourceHandler (typeof (FileImageSource), typeof (Android.Glide.ImageViewHandler))]
-[assembly: ExportImageSourceHandler (typeof (StreamImageSource), typeof (Android.Glide.ImageViewHandler))]
-[assembly: ExportImageSourceHandler (typeof (UriImageSource), typeof (Android.Glide.ImageViewHandler))]
-
 namespace Android.Glide
 {
 	[Preserve (AllMembers = true)]
-	public class ImageViewHandler : IImageViewHandler
+	public class ImageViewHandler : IImageViewHandler, IImageSourceHandler
 	{
 		public ImageViewHandler ()
 		{
@@ -23,6 +21,12 @@ namespace Android.Glide
 		{
 			Forms.Debug ("IImageViewHandler of type `{0}`, `{1}` called.", GetType (), nameof (LoadImageAsync));
 			await imageView.LoadViaGlide (source, token);
+		}
+
+		public async Task<Bitmap> LoadImageAsync (ImageSource source, Context context, CancellationToken token = default)
+		{
+			Forms.Debug ("IImageViewHandler of type `{0}`, `{1}` called.", GetType (), nameof (LoadImageAsync));
+			return await source.LoadViaGlide (context, token);
 		}
 	}
 }

--- a/glidex.forms/ImageViewHandler.cs
+++ b/glidex.forms/ImageViewHandler.cs
@@ -7,6 +7,10 @@ using Android.Widget;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
 
+[assembly: ExportImageSourceHandler (typeof (FileImageSource), typeof (Android.Glide.ImageViewHandler))]
+[assembly: ExportImageSourceHandler (typeof (StreamImageSource), typeof (Android.Glide.ImageViewHandler))]
+[assembly: ExportImageSourceHandler (typeof (UriImageSource), typeof (Android.Glide.ImageViewHandler))]
+
 namespace Android.Glide
 {
 	[Preserve (AllMembers = true)]


### PR DESCRIPTION
This closes #69 
To test it simply add followings to MainPage.xaml

```xml
NavigationPage.TitleIconImageSource="https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png"
```
This uses Glidex.forms image handler's method which accepts ImageSource only for UriImageSources

We need another issue in XF, because it calls our handler's method for UriImageSources but it doesn't call the same method for FileImageSources and StreamImageSources )-: