### PR TITLE
Fix flickering for VisualStateManager usage

### DIFF
--- a/glidex.forms/GlideExtensions.cs
+++ b/glidex.forms/GlideExtensions.cs
@@ -37,7 +37,7 @@ namespace Android.Glide
 						var drawable = ResourceManager.GetDrawableByName (fileName);
 						if (drawable != 0) {
 							Forms.Debug ("Loading `{0}` as an Android resource", fileName);
-							builder = request.Load (drawable);
+							builder = request.Load (drawable).Placeholder (drawable);
 						} else {
 							Forms.Debug ("Loading `{0}` from disk", fileName);
 							builder = request.Load (fileName);


### PR DESCRIPTION
Context: https://github.com/jonathanpeppers/glidex/issues/71

The `VisualStateManagerPage` displays an issue where you see an image
flicker for a moment when tapping a button for the first time.
Subsequent taps work fine.

I found that setting a `Placeholder` solved the problem completely,
and I don't see flickering any longer.

Not sure if this fully fixes #71 as there are some mentions of
`FlexLayout`.