### PR TITLE
Useful improvements from PR #70

### DIFF
--- a/glidex.forms.sample/Resources/layout/Tabbar.axml
+++ b/glidex.forms.sample/Resources/layout/Tabbar.axml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.TabLayout xmlns:android="http://schemas.android.com/apk/res/android"
+﻿<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.tabs.TabLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/sliding_tabs"
     android:layout_width="match_parent"

--- a/glidex.forms.sample/Resources/layout/Toolbar.axml
+++ b/glidex.forms.sample/Resources/layout/Toolbar.axml
@@ -1,4 +1,4 @@
-<android.support.v7.widget.Toolbar
+﻿<androidx.appcompat.widget.Toolbar
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/toolbar"
     android:layout_width="match_parent"
@@ -6,4 +6,3 @@
     android:background="?attr/colorPrimary"
     android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
     android:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
-

--- a/glidex.forms/GlideExtensions.cs
+++ b/glidex.forms/GlideExtensions.cs
@@ -60,7 +60,7 @@ namespace Android.Glide
 								CancelGlide (imageView);
 								return;
 							}
-							stream.CopyTo (memoryStream);
+							await stream.CopyToAsync (memoryStream, token);
 							builder = request.Load (memoryStream.ToArray ());
 						}
 						break;


### PR DESCRIPTION
Multiple things are cleaned up in #70, I'm pulling over the parts that make sense.

* Use `MemoryStream.CopyToAsync()`
* Use androidx and material in sample layouts