### PR TITLE
Add IImageSourceHandler for NavigationPage.TitleIconImageSource

### DIFF
--- a/glidex.forms.sample/Forms/MainPage.xaml
+++ b/glidex.forms.sample/Forms/MainPage.xaml
@@ -3,6 +3,7 @@
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Android.Glide.Sample.MainPage"
-    Title="GlideX.Forms Sample">
+    Title="GlideX.Forms Sample"
+    NavigationPage.TitleIconImageSource="https://api.nuget.org/v3-flatcontainer/glidex.forms/2.1.0.470/icon">
   <ListView ItemsSource="{Binding}" ItemSelected="OnItemSelected" />
 </ContentPage>

--- a/glidex.forms/IGlideHandler.cs
+++ b/glidex.forms/IGlideHandler.cs
@@ -19,5 +19,13 @@ namespace Android.Glide
 		/// <param name="token">The CancellationToken if you need it</param>
 		/// <returns>True if the image was handled. Return false if you need the image to be cleared for you.</returns>
 		bool Build (ImageView imageView, ImageSource source, RequestBuilder builder, CancellationToken token);
+
+		/// <summary>
+		/// A callback that glidex.forms calls prior to making default calls to Glide. This version is for IImageSourceHandler calls.
+		/// </summary>
+		/// <param name="source">The ImageSource from Xamarin.Forms</param>
+		/// <param name="builder">Might be null, the Glide RequestBuilder object to work with. Set to null to cancel the request.</param>
+		/// <param name="token">The CancellationToken if you need it</param>
+		void Build (ImageSource source, ref RequestBuilder builder, CancellationToken token) { }
 	}
 }

--- a/glidex.forms/ImageViewHandler.cs
+++ b/glidex.forms/ImageViewHandler.cs
@@ -1,5 +1,7 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using Android.Content;
+using Android.Graphics;
 using Android.Runtime;
 using Android.Widget;
 using Xamarin.Forms;
@@ -12,17 +14,23 @@ using Xamarin.Forms.Platform.Android;
 namespace Android.Glide
 {
 	[Preserve (AllMembers = true)]
-	public class ImageViewHandler : IImageViewHandler
+	public class ImageViewHandler : IImageViewHandler, IImageSourceHandler
 	{
 		public ImageViewHandler ()
 		{
 			Forms.Debug ("IImageViewHandler of type `{0}`, instance created.", GetType ());
 		}
 
-		public async Task LoadImageAsync (ImageSource source, ImageView imageView, CancellationToken token = default (CancellationToken))
+		public async Task LoadImageAsync (ImageSource source, ImageView imageView, CancellationToken token = default)
 		{
 			Forms.Debug ("IImageViewHandler of type `{0}`, `{1}` called.", GetType (), nameof (LoadImageAsync));
 			await imageView.LoadViaGlide (source, token);
+		}
+
+		public async Task<Bitmap> LoadImageAsync (ImageSource source, Context context, CancellationToken token = default)
+		{
+			Forms.Debug ("IImageSourceHandler of type `{0}`, `{1}` called.", GetType (), nameof (LoadImageAsync));
+			return await source.LoadViaGlide (context, token);
 		}
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/glidex/issues/69
Context: https://github.com/xamarin/Xamarin.Forms/issues/11676

There are certain Android APIs where `IImageViewHandler` is not
possible for Xamarin.Forms to be able to call. For example, if you
have an `IMenuItem`:

    menuItem.SetIcon (drawable);

`IImageViewHandler` requires an `ImageView` -- so Xamarin.Forms must
fall back to `IImageSourceHandler` for this to work at *all*.

Adding `IImageSourceHandler` required various refactoring, but things
seem to work as before. `IImageViewHandler` appears to be called by
Xamarin.Forms when it *should* be, and `IImageSourceHandler` is called
as a fallback.

Perhaps in MAUI, `IImageViewHandler` should have an additional method
for `IMenuItem`?