### PR TITLE
[ci] update boots, don't provision Mono/Xamarin.iOS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ trigger:
 jobs:
 - job: windows
   pool:
-    name: Hosted Windows 2019 with VS2019
+    vmImage: windows-latest
     demands:
     - msbuild
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,8 +12,7 @@ jobs:
     demands:
     - msbuild
   steps:
-  - powershell: |
-      ./build.ps1 -t AppVeyor
+  - powershell: .\build.ps1 -t CI
     displayName: build
   - task: PublishPipelineArtifact@0
     displayName: artifacts

--- a/build.cake
+++ b/build.cake
@@ -67,7 +67,7 @@ Task("NuGet-Push")
 Task("Default")
     .IsDependentOn("NuGet-Package");
 
-Task("AppVeyor")
+Task("CI")
     .IsDependentOn("Boots")
     .IsDependentOn("NuGet-Package");
 

--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,4 @@
-#addin nuget:?package=Cake.Boots&version=1.0.2.421
+#addin nuget:?package=Cake.Boots&version=1.0.2.482
 #load "helpers.cake"
 
 // Input args
@@ -28,10 +28,6 @@ if (!string.IsNullOrEmpty(buildNumber))
 Task("Boots")
     .Does(async () =>
     {
-        if (!IsRunningOnWindows ()) {
-            await Boots (Product.Mono,       ReleaseChannel.Stable);
-            await Boots (Product.XamariniOS, ReleaseChannel.Preview);
-        }
         await Boots (Product.XamarinAndroid, ReleaseChannel.Preview);
     });
 


### PR DESCRIPTION
* Bump to Cake.Boots 1.0.2.482.
* Use `vmImage: windows-latest`.
* CI here runs on Windows. I don't see why we need to provision other stuff.