### PR TITLE
Checking for file name matches

### DIFF
--- a/glidex.forms.sample/Forms/Images.cs
+++ b/glidex.forms.sample/Forms/Images.cs
@@ -9,7 +9,7 @@ namespace Android.Glide.Sample
 	{
 		static readonly Random random = new Random ();
 		static readonly string tempDir = Path.Combine (Path.GetTempPath (), "glide.forms.sample");
-		static readonly string tempPath = Path.Combine (tempDir, "temp.jpg");
+		static readonly string tempPath = Path.Combine (tempDir, "patch1.jpg");
 		const int MaxImages = 12;
 
 		public static IEnumerable<ImageSource> RandomSources ()

--- a/glidex.forms/GlideExtensions.cs
+++ b/glidex.forms/GlideExtensions.cs
@@ -118,7 +118,7 @@ namespace Android.Glide
 		{
 			RequestBuilder builder;
 			var fileName = source.File;
-			var drawable = ResourceManager.GetDrawableByName (fileName);
+			var drawable = File.Exists(fileName) ? 0 : ResourceManager.GetDrawableByName(fileName);
 			if (drawable != 0) {
 				Forms.Debug ("Loading `{0}` as an Android resource", fileName);
 				builder = request.Load (drawable);


### PR DESCRIPTION
`ResourceManager.GetDrawableByName()` does not work correctly, it cuts the full path to a file to its name.
Therefore, the problem occur if the fileNames match and sometimes if they consist only of numbers.